### PR TITLE
🐳 feat(docker): browserとinfinityイメージのビルドをワークフローに追加

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Build and Push Docker Images
 
 on:
   push:
@@ -10,7 +10,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -18,6 +17,25 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        include:
+          - name: agent3
+            context: ./clawdbot
+            dockerfile: ./clawdbot/Dockerfile
+            image_suffixes: |
+              sunwood-ai-oss-hub/agentos-clawd-agent3
+              ${{ github.repository }}
+          - name: browser
+            context: .
+            dockerfile: ./docker/Dockerfile.browser
+            image_suffixes: |
+              sunwood-ai-oss-hub/agentos-clawd-browser
+          - name: infinity
+            context: .
+            dockerfile: ./docker/Dockerfile.infinity
+            image_suffixes: |
+              sunwood-ai-oss-hub/agentos-infinity
 
     steps:
       - name: Checkout repository
@@ -35,13 +53,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
+      - name: Extract metadata for ${{ matrix.name }}
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            ${{ env.REGISTRY }}/sunwood-ai-oss-hub/openclaw-agent3
+          images: ${{ join(format('{0}/{1}', env.REGISTRY, matrix.image_suffixes), '\n') }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -50,11 +66,11 @@ jobs:
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push
+      - name: Build and push ${{ matrix.name }}
         uses: docker/build-push-action@v6
         with:
-          context: ./clawdbot
-          file: ./clawdbot/Dockerfile
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## 概要

Dockerビルドワークフローを更新し、\`Dockerfile.browser\` と \`Dockerfile.infinity\` のビルド・プッシュを追加します。

## 変更内容

- ワークフローをマトリックスビルド化し、3つのイメージを並列ビルド
- agent3: \`ghcr.io/sunwood-ai-oss-hub/agentos-clawd-agent3\`
- browser: \`ghcr.io/sunwood-ai-oss-hub/agentos-clawd-browser\`
- infinity: \`ghcr.io/sunwood-ai-oss-hub/agentos-infinity\`

## テスト

- [ ] ワークフローが正常に実行されること
- [ ] 3つのイメージが正しくビルド・プッシュされること

Refs #30

Co-Authored-By: Claude <noreply@anthropic.com>